### PR TITLE
Allow custom drill decimal format

### DIFF
--- a/src/drill-parser.coffee
+++ b/src/drill-parser.coffee
@@ -19,11 +19,11 @@ ZERO_BACKUP = 'L'
 PLACES_BACKUP = [ 2, 4 ]
 
 class DrillParser
-  constructor: ->
+  constructor: (places) ->
     # format for parsing coordinates, set by each file
     # excellon specifies which zeros to keep, but here we're going to treat it
     # as suppression to match gerber
-    @format = { zero: null, places: null }
+    @format = { zero: null, places: places ? null }
     # format of the drill file
     # I don't think this is ever going to be used but whatever
     @fmat = 'FMAT,2'
@@ -42,13 +42,13 @@ class DrillParser
     # inches command
     else if block is INCH_COMMAND[@fmat] or block.match /INCH/
       # set the format to 2.4
-      @format.places = [2, 4]
+      @format.places ?= [2, 4]
       # add set units object
       command.set = { units: 'in' }
     # metric command
     else if block is METRIC_COMMAND or block.match /METRIC/
       # set the format to 3.3
-      @format.places = [3, 3]
+      @format.places ?= [3, 3]
       # add set units command object
       command.set = { units: 'mm' }
     # absolute notation

--- a/src/gerber-to-svg.coffee
+++ b/src/gerber-to-svg.coffee
@@ -25,13 +25,13 @@ module.exports = (gerber, options = {}) ->
   # or we got a string, so plot the thing
   # get the correct reader and parser
   if opts.drill
-    Reader = require './drill-reader'
-    Parser = require './drill-parser'
+    Reader = new (require './drill-reader') gerber
+    Parser = new (require './drill-parser') options.drillFormat
   else
-    Reader = require './gerber-reader'
-    Parser = require './gerber-parser'
+    Reader = new (require './gerber-reader') gerber
+    Parser = new (require './gerber-parser')
   # create the plotter
-  p = new Plotter gerber, Reader, Parser
+  p = new Plotter Reader, Parser
   # try to plot
   try
     xmlObject = p.plot()

--- a/src/plotter.coffee
+++ b/src/plotter.coffee
@@ -17,9 +17,7 @@ arcEps = 0.0000001
 ASSUMED_UNITS = 'in'
 
 class Plotter
-  constructor: (file = '', Reader, Parser) ->
-    if Reader? then @reader = new Reader file
-    if Parser? then @parser = new Parser
+  constructor: (@reader, @parser) ->
     # tools and macros
     @macros = {}
     @tools = {}

--- a/test/drill-parser_test.coffee
+++ b/test/drill-parser_test.coffee
@@ -59,6 +59,9 @@ describe 'NC drill file parser', ->
     p.format.places = null
     p.parseCommand 'METRIC'
     p.format.places.should.eql [ 3, 3 ]
+  it 'shoud use custom format if specified', ->
+    p = new Parser [ 4, 4 ]
+    p.format.places.should.eql [ 4, 4 ]
   describe 'tool definitions', ->
     it 'should return a define tool command for tool definitions', ->
       p.parseCommand 'T1C0.015'
@@ -123,6 +126,10 @@ describe 'NC drill file parser', ->
       p.format.places = [3,3]
       p.parseCommand('X08Y0124').should.eql {
         op: { do: 'flash', x: 80, y: 12.4 }
+      }
+      p.format.places = [4,4]
+      p.parseCommand('X00398675Y00130275').should.eql {
+        op: { do: 'flash', x: 39.8675, y: 13.0275 }
       }
     it 'should recognize a tool change at the beginning or end of the line', ->
       p.format.zero = 'T'

--- a/test/drill-parser_test.coffee
+++ b/test/drill-parser_test.coffee
@@ -56,6 +56,7 @@ describe 'NC drill file parser', ->
   it 'should use 3.3 format for metric and 2.4 for inches', ->
     p.parseCommand 'INCH'
     p.format.places.should.eql [ 2, 4 ]
+    p.format.places = null
     p.parseCommand 'METRIC'
     p.format.places.should.eql [ 3, 3 ]
   describe 'tool definitions', ->

--- a/test/plotter_plot_test.coffee
+++ b/test/plotter_plot_test.coffee
@@ -7,7 +7,7 @@ fs = require 'fs'
 describe 'the plot method of the Plotter class', ->
   it 'should plot example 1 from the gerber spec', ->
     testGerber= fs.readFileSync 'test/gerber/gerber-spec-example-1.gbr', 'utf-8'
-    p = new Plotter testGerber, GerberReader, GerberParser
+    p = new Plotter (new GerberReader testGerber), new GerberParser
     p.plot()
     p.group.g.should.containDeep {
       _: [
@@ -21,10 +21,10 @@ describe 'the plot method of the Plotter class', ->
 
   it 'should plot example 2 from the gerber spec', ->
     testGerber= fs.readFileSync 'test/gerber/gerber-spec-example-2.gbr', 'utf-8'
-    p = new Plotter testGerber, GerberReader, GerberParser
+    p = new Plotter (new GerberReader testGerber), new GerberParser
     (-> p.plot()).should.not.throw
 
   it 'should throw an error if a gerber file ends without an M02*', ->
     testGerber = '%FSLAX34Y34*%%MOIN*%%ADD10C,0.5*%X0Y0D03*'
-    p = new Plotter testGerber, GerberReader, GerberParser
+    p = new Plotter (new GerberReader testGerber), new GerberParser
     (-> p.plot()).should.throw /end of file/

--- a/test/plotter_test.coffee
+++ b/test/plotter_test.coffee
@@ -44,7 +44,7 @@ describe 'Plotter class', ->
         (-> p.command { set: { currentTool: 'D10' } }).should.throw /tool/
       it 'should not throw missing tool exception for drill files', ->
         # drill files sometimes do this, so check for it
-        p = new Plotter '', null, require '../src/drill-parser'
+        p = new Plotter null, new (require '../src/drill-parser')
         (-> p.command { set: { currentTool: 'T0' } } ).should.not.throw()
       it 'should throw if region mode is on', ->
         p.region = true
@@ -144,7 +144,7 @@ describe 'Plotter class', ->
           .should.throw /format/
 
       it 'should assume notation is absolute if not set on a drill file', ->
-        p = new Plotter '', null, require '../src/drill-parser'
+        p = new Plotter null, new (require '../src/drill-parser')
         p.units = 'in'
         p.command { tool: { T1: { dia: 1 } } }
         (-> p.command { op: { do: 'flash', x: 1, y: 1 } }).should.not.throw()


### PR DESCRIPTION
In altium you can specify a whole range of different formats (eg 4:4) for export, and the default does not seem to be the same as excellon's default.
Here I allow the format to be passed in via the options.  Not sure if you'd like to handle this in another way?
Another/additional option: Altium includes a comment that contains the format in the file, here's a branch that extracts it from the comments if it's present - https://github.com/circuithub/gerber-to-svg/tree/feat/parse-drill-format