### PR TITLE
FIX: treat "no zero suppression" as "suppress tailing zero"

### DIFF
--- a/src/gerber-parser.coffee
+++ b/src/gerber-parser.coffee
@@ -19,6 +19,10 @@ class GerberParser extends Parser
   # parse a format block
   parseFormat: (p, c) ->
     zero = if p[2] is 'L' or p[2] is 'T' then p[2] else null
+    # FIX: treat "no zero suppression" as "suppress tailing zero"
+    if not zero?
+      p = ' ' + p
+      zero = 'T'
     nota = if p[3] is 'A' or p[3] is 'I' then p[3] else null
     if p[4] is 'X' and p[7] is 'Y' and p[5..6] is p[8..9] and
     p[5] < 8 and p[6] < 8

--- a/src/gerber-parser.coffee
+++ b/src/gerber-parser.coffee
@@ -30,8 +30,14 @@ class GerberParser extends Parser
     if not (m = p.match reFS)
       throw new Error 'invalid format specification'
     [_, zero, nota, pN, pM] = m
-    if zero isnt 'L' and zero isnt 'T' then zero = 'L' # defaults to leading
-    if nota isnt 'A' and nota isnt 'I' then nota = 'A' # defaults to absolute
+    if zero isnt 'L' and zero isnt 'T'
+      console.warn 'gerber zero suppression is not specified. assuming
+        leading zero suppression (same as no zero suppression)'
+      zero = 'L'
+    if nota isnt 'A' and nota isnt 'I'
+      console.warn 'gerber coordinate notation is not specified. assuming
+        absolute notation'
+      nota = 'A'
     @format.zero ?= zero
     @format.places ?= [Number(pN), Number(pM)]
     c.set ?= {}

--- a/test/gerber-parser_test.coffee
+++ b/test/gerber-parser_test.coffee
@@ -29,12 +29,27 @@ describe 'gerber command parser', ->
       }
       expect( p.format.zero ).to.eql 'L'
       expect( p.format.places ).to.eql [3,4]
-      p = new Parser()
+
+    it 'should handle it with good options', ->
       expect( p.parseCommand param 'FSTIX77Y77' ).to.eql {
         set: { notation: 'I' }
       }
       expect( p.format.zero ).to.eql 'T'
       expect( p.format.places ).to.eql [7,7]
+
+    it 'should handle it with omitted options and use defaults', ->
+      expect( p.parseCommand param 'FSX34Y34' ).to.eql {
+        set: { notation: 'A' }
+      }
+      expect( p.format.zero ).to.eql 'L'
+      expect( p.format.places ).to.eql [3,4]
+
+    it 'should handle it with non-standard options and use defaults', ->
+      expect( p.parseCommand param 'FSNAX34Y34' ).to.eql {
+        set: { notation: 'A' }
+      }
+      expect( p.format.zero ).to.eql 'L'
+      expect( p.format.places ).to.eql [3,4]
 
     it 'should not override user set places or zero suppression', ->
       p = new Parser {places: [4, 7], zero: 'T'}
@@ -43,8 +58,6 @@ describe 'gerber command parser', ->
       expect(p.format.places).to.eql [4,7]
 
     it 'should throw error for bad options', ->
-      expect( -> p.parseCommand param 'FSLPX34Y34' ).to.throw /invalid/
-      expect( -> p.parseCommand param 'FSFAX34Y34' ).to.throw /invalid/
       expect( -> p.parseCommand param 'FSLAX12Y34' ).to.throw /invalid/
       expect( -> p.parseCommand param 'FSLAX34' ).to.throw /invalid/
       expect( -> p.parseCommand param 'FSLAY34' ).to.throw /invalid/

--- a/test/gerber-parser_test.coffee
+++ b/test/gerber-parser_test.coffee
@@ -1,6 +1,9 @@
 # test suite for GerberParser class
 expect = require('chai').expect
 Parser = require '../src/gerber-parser'
+
+# warnings hook
+warnings = require './warn-capture'
 # svg coordinate factor
 factor = require('../src/svg-coord').factor
 
@@ -38,18 +41,25 @@ describe 'gerber command parser', ->
       expect( p.format.places ).to.eql [7,7]
 
     it 'should handle it with omitted options and use defaults', ->
+      warnings.hook()
       expect( p.parseCommand param 'FSX34Y34' ).to.eql {
         set: { notation: 'A' }
       }
       expect( p.format.zero ).to.eql 'L'
       expect( p.format.places ).to.eql [3,4]
+      w = warnings.unhook()
+      expect( w ).to.match /assuming leading zero suppression/
+      expect( w ).to.match /assuming absolute notation/
+
 
     it 'should handle it with non-standard options and use defaults', ->
+      warnings.hook()
       expect( p.parseCommand param 'FSNAX34Y34' ).to.eql {
         set: { notation: 'A' }
       }
       expect( p.format.zero ).to.eql 'L'
       expect( p.format.places ).to.eql [3,4]
+      expect( warnings.unhook() ).to.match /assuming leading zero suppression/
 
     it 'should not override user set places or zero suppression', ->
       p = new Parser {places: [4, 7], zero: 'T'}


### PR DESCRIPTION
Although this is not specified in the gerber file format specs, Altium does offer an option to generate gerber with no zero suppression (i.e. missing `p[2]`), which I always use to avoid problem with fab. This patch makes gerber parser accept these files.